### PR TITLE
Support extending subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ memodir and assetsdir can be used `~/` prefix or `$HOME` or OS specific environm
 |[cho](https://github.com/mattn/cho)   |selectcmd = "cho"|
 |[fzf](https://github.com/junegunn/fzf)|selectcmd = "fzf"|
 
+## Extend With Custom Commands
+
+You can extend memo with custom commands. 
+Place an executable file with a name like `memo-foo` in your $PATH, memo can use it as a subcommand: `memo foo`.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ column = 30                       # column size for list command
 selectcmd = "peco"                # selector command for edit command
 grepcmd = "grep -nH"              # grep command executable
 assetsdir = "/path/to/assets"     # assets directory for serve command
+pluginsdir = "path/to/plugins"    # plugins directory for plugin commands. default '~/.config/memo/plugins'.
 ```
 
 memodir and assetsdir can be used `~/` prefix or `$HOME` or OS specific environment variables. editor, selectcmd and grepcmd can be used placeholder below.
@@ -96,10 +97,11 @@ memodir and assetsdir can be used `~/` prefix or `$HOME` or OS specific environm
 |[cho](https://github.com/mattn/cho)   |selectcmd = "cho"|
 |[fzf](https://github.com/junegunn/fzf)|selectcmd = "fzf"|
 
-## Extend With Custom Commands
+## Extend With Plugin Commands
 
 You can extend memo with custom commands. 
-Place an executable file with a name like `memo-foo` in your $PATH, memo can use it as a subcommand: `memo foo`.
+Place an executable file in your `pluginsdir`, memo can use it as a subcommand.
+For example, If you place `foo` file in your `pluginsdir`, you can run it by `memo foo`.
 
 ## License
 

--- a/main.go
+++ b/main.go
@@ -278,31 +278,7 @@ func run() int {
 	app.Usage = "Memo Life For You"
 	app.Version = VERSION
 	app.Commands = commands
-	app.Action = func(c *cli.Context) error {
-		args := c.Args()
-		if args.Present() {
-			var cfg config
-			err := cfg.load()
-			if err != nil {
-				return err
-			}
-			xcmdpath := filepath.Join(cfg.PluginsDir, args.First())
-			_, err = exec.LookPath(xcmdpath)
-			if err != nil {
-				return fmt.Errorf("'%s' is not a memo command. see 'memo help'", args.First())
-			}
-
-			// run external command as a memo subcommand.
-			xargs := args.Tail()
-			cmd := exec.Command(xcmdpath, xargs...)
-			cmd.Stderr = os.Stderr
-			cmd.Stdout = os.Stdout
-			cmd.Stdin = os.Stdin
-			return cmd.Run()
-		}
-
-		return cli.ShowAppHelp(c)
-	}
+	app.Action = appRun
 
 	return msg(app.Run(os.Args))
 }
@@ -709,6 +685,32 @@ func cmdServe(c *cli.Context) error {
 	}
 	browser.OpenURL(url)
 	return http.ListenAndServe(addr, nil)
+}
+
+func appRun(c *cli.Context) error {
+	args := c.Args()
+	if args.Present() {
+		var cfg config
+		err := cfg.load()
+		if err != nil {
+			return err
+		}
+		xcmdpath := filepath.Join(cfg.PluginsDir, args.First())
+		_, err = exec.LookPath(xcmdpath)
+		if err != nil {
+			return fmt.Errorf("'%s' is not a memo command. see 'memo help'", args.First())
+		}
+
+		// run external command as a memo subcommand.
+		xargs := args.Tail()
+		cmd := exec.Command(xcmdpath, xargs...)
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		cmd.Stdin = os.Stdin
+		return cmd.Run()
+	}
+
+	return cli.ShowAppHelp(c)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -268,6 +268,27 @@ func run() int {
 	app.Usage = "Memo Life For You"
 	app.Version = VERSION
 	app.Commands = commands
+	app.Action = func(c *cli.Context) error {
+		args := c.Args()
+		if args.Present() {
+			xcmd := fmt.Sprintf("memo-%s", args.First())
+			xcmdpath, err := exec.LookPath(xcmd)
+			if err != nil {
+				return fmt.Errorf("'%s' is not a memo command. see 'memo help'", args.First())
+			}
+
+			// run external command as a memo subcommand.
+			xargs := args.Tail()
+			cmd := exec.Command(xcmdpath, xargs...)
+			cmd.Stderr = os.Stderr
+			cmd.Stdout = os.Stdout
+			cmd.Stdin = os.Stdin
+			return cmd.Run()
+		}
+
+		return cli.ShowAppHelp(c)
+	}
+
 	return msg(app.Run(os.Args))
 }
 


### PR DESCRIPTION
This PR is to support to extend memo with custom commands like `git`.

For example:

Create `memo-select` like the following. This command is an extension of `memo edit`, that supports to filter memos by title.

```
#!/usr/bin/env bash

selected=$(memo list --format="{{.Title}}#{{.File}}" | column -t -s"#" | peco | perl -nle '/(\S+)$/ and print $1')
if [ -z "$selected" ]; then
    echo "No files selected" 1>&2
    exit 0
fi
exec memo e "$selected"
```

Add executable permission to the file and place it in your $PATH. You can use `memo select` command.

Demo:

![memo3](https://cloud.githubusercontent.com/assets/761462/22954890/6ddd9e92-f35c-11e6-9919-b9d17f022721.gif)

If you like it, Please merge it.


