### PR TITLE
Check file existence when creating new one

### DIFF
--- a/main.go
+++ b/main.go
@@ -424,6 +424,11 @@ func (cfg *config) runcmd(command, pattern string, files ...string) error {
 	return cmd.Run()
 }
 
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil
+}
+
 func cmdNew(c *cli.Context) error {
 	var cfg config
 	err := cfg.load()
@@ -449,6 +454,11 @@ func cmdNew(c *cli.Context) error {
 	file = time.Now().Format("2006-01-02-") + escape(title) + ".md"
 	file = filepath.Join(cfg.MemoDir, file)
 	t := template.Must(template.New("memo").Parse(templateMemoContent))
+
+	if fileExists(file) {
+		return fmt.Errorf("file %s already exists", file)
+	}
+
 	f, err := os.Create(file)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR is to check existence of the file for command `memo new`.

I executed `memo new` with "Title: 日報", and wrote some content to `2017-02-24-日報.md`. After that, I also executed `memo new` with "Title: 日報", and content I wrote disappeared(`os.Open` truncate the file content if file already exists ([here](https://github.com/golang/go/blob/master/src/os/file.go#L239-L246))) :cry:. So I modify `cmdNew` to check existence of the file.