### PR TITLE
Sort entries(recently first)

### DIFF
--- a/main.go
+++ b/main.go
@@ -250,7 +250,7 @@ func filterMarkdown(files []string) []string {
 			newfiles = append(newfiles, file)
 		}
 	}
-	sort.Strings(newfiles)
+	sort.Sort(sort.Reverse(sort.StringSlice(newfiles)))
 	return newfiles
 }
 


### PR DESCRIPTION
This PR is to reverse the order of markdown files(recently first).

When I see my entries on my browser via `memo serve` or `memo list`, the entry I created appear at the end of these entries. If I have many entries in `memodir`, I need to scroll to bottom to see recent entries. People will often see the recent entries than old ones, so this modification would be useful I think.