### PR TITLE
Set the default filename and title in cmdNew

### DIFF
--- a/main.go
+++ b/main.go
@@ -453,7 +453,7 @@ func cmdNew(c *cli.Context) error {
 		}
 		title = scanner.Text()
 		if title == "" {
-			file = time.Now().Format("2006-01-02") + escape(title) + ".md"
+			file = time.Now().Format("2006-01-02") + ".md"
 			title = time.Now().Format("2006-01-02")
 		} else {
 			file = time.Now().Format("2006-01-02-") + escape(title) + ".md"

--- a/main.go
+++ b/main.go
@@ -452,8 +452,14 @@ func cmdNew(c *cli.Context) error {
 			return scanner.Err()
 		}
 		title = scanner.Text()
+		if title == "" {
+			file = time.Now().Format("2006-01-02") + escape(title) + ".md"
+			title = time.Now().Format("2006-01-02")
+		} else {
+			file = time.Now().Format("2006-01-02-") + escape(title) + ".md"
+		}
+
 	}
-	file = time.Now().Format("2006-01-02-") + escape(title) + ".md"
 	file = filepath.Join(cfg.MemoDir, file)
 	t := template.Must(template.New("memo").Parse(templateMemoContent))
 

--- a/main.go
+++ b/main.go
@@ -453,8 +453,9 @@ func cmdNew(c *cli.Context) error {
 		}
 		title = scanner.Text()
 		if title == "" {
-			file = time.Now().Format("2006-01-02") + ".md"
 			title = time.Now().Format("2006-01-02")
+			file = title + ".md"
+			
 		} else {
 			file = time.Now().Format("2006-01-02-") + escape(title) + ".md"
 		}


### PR DESCRIPTION
This PR is to change the behavior of making a new memo without giving the title.

I write a diary with `memo` and it works great. However, setting title for everyday is a bit annoying and current default filename `yyyy-mm-dd-.md` looks ugly.

Therefore, I suggest to change the default behavior of `memo new` with empty title like this:

filename: `yyyy-mm-dd.md`
body: 
```
# yyyy-mm-dd


```

I think setting some default title is reasonable, but I'm not sure that `yyyy-mm-dd` is a good choice for the default. In addition, it do break the consistency of filenames. Thus, configurable the defaults like `defaultname` and `defaulttitle` in `config.toml` can work better but it's just an idea.