### PR TITLE
Open existing file rather than returning an error.

### DIFF
--- a/main.go
+++ b/main.go
@@ -458,7 +458,7 @@ func cmdNew(c *cli.Context) error {
 	t := template.Must(template.New("memo").Parse(templateMemoContent))
 
 	if fileExists(file) {
-		return fmt.Errorf("file %s already exists", file)
+		return cfg.runcmd(cfg.Editor, "", file)
 	}
 
 	f, err := os.Create(file)


### PR DESCRIPTION
This PR is to change the behavior of `memo new` when there already exists a file that have the given title in `memo new`.

Current implementation checks the existing file and avoids overwriting. It's a good idea. However, it seems that opening the file rather than returning an error is more convenient. Even if the user doesn't want to modify the existing file, he/she can just go back to the terminal and execute `memo new` again with another title.