### PR TITLE
Set file name with arguments in cmdNew

### DIFF
--- a/main.go
+++ b/main.go
@@ -442,6 +442,7 @@ func cmdNew(c *cli.Context) error {
 	var file string
 	if c.Args().Present() {
 		title = c.Args().First()
+		file = time.Now().Format("2006-01-02-") + escape(title) + ".md"
 	} else {
 		fmt.Print("Title: ")
 		scanner := bufio.NewScanner(os.Stdin)


### PR DESCRIPTION
This PR is to fix bug didn't set file name when type below command.
`$ memo new title`