### PR TITLE
To follow cfg.MemoDir: apply filepath.ToSlash() for cfg.PluginsDir

### DIFF
--- a/main.go
+++ b/main.go
@@ -217,7 +217,7 @@ func (cfg *config) load() error {
 	cfg.AssetsDir = "."
 	dir = filepath.Join(confDir, "plugins")
 	os.MkdirAll(dir, 0700)
-	cfg.PluginsDir = dir
+	cfg.PluginsDir = filepath.ToSlash(dir)
 
 	dir = os.Getenv("MEMODIR")
 	if dir != "" {


### PR DESCRIPTION
On Windows, memo initializes config file with slash-separated `memodir` and backslash-separated `pluginsdir`.
I prefer unified by slash to unified by backslash or not unified.