### PR TITLE
Use Bourne shell single quoting in shellquote

### DIFF
--- a/util_posix.go
+++ b/util_posix.go
@@ -5,5 +5,5 @@ package main
 import "fmt"
 
 func shellquote(s string) string {
-	return fmt.Sprintf("%q", s)
+	return `'` + strings.Replace(s, `'`, `'\''`, -1) + `'`
 }


### PR DESCRIPTION
The %q directive in the `fmt` package isn't guaranteed to produce correct
quoting for a Bourne shell, not to mention others. Since shell single quoting
is so easy (for precisely this reason), commit uses it.