### PR TITLE
Apply gfm styles by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ const templateBodyContent = `
   <title>{{.Name}}</title>
   <link href="/assets/gfm/gfm.css" media="all" rel="stylesheet" type="text/css" />
 </head>
-<body>
+<body class="markdown-body">
 {{.Body}}</body>
 </html>
 `


### PR DESCRIPTION
The gfm style sheet is being referenced and loaded; but the styles are not being applied because of a missing class attribute.

This PR adds the missing style attribute so that the markdown gets rendered correctly.