### PR TITLE
make a vertical scroll bar appeared for long articles.

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,8 +69,11 @@ const templateBodyContent = `
   <title>{{.Name}}</title>
   <link href="/assets/gfm/gfm.css" media="all" rel="stylesheet" type="text/css" />
 </head>
-<body class="markdown-body">
-{{.Body}}</body>
+<body>
+	<main class="markdown-body">
+	{{.Body}}
+	</main>
+</body>
 </html>
 `
 


### PR DESCRIPTION
The "markdown-body" class is applied to the <body> tag, so the vertical scroll bar does not appear for long articles.
This PR adds a <main> tag in the <body> tag and applies the class to it.