### PR TITLE
Update Makefile to make Release job work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,14 @@ show-version: $(GOBIN)/gobump
 	@gobump show -r .
 
 $(GOBIN)/gobump:
-	@cd && go get github.com/x-motemen/gobump/cmd/gobump
+	@cd && go install github.com/x-motemen/gobump/cmd/gobump@latest
 
 .PHONY: cross
 cross: $(GOBIN)/goxz
 	goxz -n $(BIN) -pv=v$(VERSION) -build-ldflags=$(BUILD_LDFLAGS) .
 
 $(GOBIN)/goxz:
-	cd && go get github.com/Songmu/goxz/cmd/goxz
+	cd && go install github.com/Songmu/goxz/cmd/goxz@latest
 
 .PHONY: test
 test: build
@@ -58,4 +58,4 @@ upload: $(GOBIN)/ghr
 	ghr "v$(VERSION)" goxz
 
 $(GOBIN)/ghr:
-	cd && go get github.com/tcnksm/ghr
+	cd && go install github.com/tcnksm/ghr@latest


### PR DESCRIPTION
In order to make Release job work, replace `go get` with `go install` in Makefile.